### PR TITLE
feat: add resource sorting by id, name, and status

### DIFF
--- a/Sources/Views/MenuBarView.swift
+++ b/Sources/Views/MenuBarView.swift
@@ -236,6 +236,32 @@ struct MenuBarView: View {
                     }
                     .menuStyle(.borderlessButton)
                     .fixedSize()
+                    
+                    Divider()
+                        .frame(height: 12)
+                    
+                    Menu {
+                        ForEach(ProxmoxViewModel.SortOption.allCases, id: \.self) { option in
+                            Button {
+                                viewModel.sortOption = option
+                            } label: {
+                                if viewModel.sortOption == option {
+                                    Label(option.rawValue, systemImage: "checkmark")
+                                } else {
+                                    Label(option.rawValue, systemImage: option.icon)
+                                }
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "arrow.up.arrow.down")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 4)
+                            .contentShape(Rectangle())
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
                 }
                 .padding(10)
                 .background(Color.primary.opacity(0.05))


### PR DESCRIPTION
<img width="478" height="563" alt="Capture d’écran 2026-01-12 à 20 12 54" src="https://github.com/user-attachments/assets/48f77caa-7836-4cc0-b8ac-ca44ea5efdad" />

close #5 